### PR TITLE
🔄 Add loading spinner to LandingPage and fetch total years of experiences through Supabase RPC

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -124,6 +124,25 @@ a:hover {
 
 
 /* Components */
+.spinner-container {
+    height: 100vh;
+    width: 100vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 40px;
+    border-radius: 8px;
+}
+
+.spinner {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    border: 5px solid rgba(255, 255, 255, 0.1);
+    border-top-color: #ff0088;
+    will-change: transform;
+}
+
 .grid-images {
     display: block;
     height: auto;


### PR DESCRIPTION
This pull request includes significant updates to the `LandingPage.vue` to enhance the user experience and add a loading spinner. Additionally, some CSS changes were made to support the new spinner component.

Enhancements to `LandingPage.vue`:

* Added `onUnmounted` lifecycle hook to clean up the animation control (`[src/views/LandingPage.vueL2-R2](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6L2-R2)`).
* Introduced a loading state with a spinner animation using `motion-v` library (`[[1]](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6R37-R48)`, `[[2]](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6R143-R164)`).
* Implemented a new function to fetch and animate the total years of experience from the backend (`[src/views/LandingPage.vueR63-R79](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6R63-R79)`).
* Updated the template to conditionally display the spinner or the main content based on the loading state (`[src/views/LandingPage.vueR143-R164](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6R143-R164)`).
* Replaced the hardcoded years of experience with a dynamically calculated value (`[src/views/LandingPage.vueL133-R176](diffhunk://#diff-f05770481dab0c6fb52802f1441df5b6329ee264a057f3773731a4229d047ec6L133-R176)`).

CSS updates:

* Added styles for the spinner container and spinner animation in `main.css` (`[src/css/main.cssR127-R145](diffhunk://#diff-36ebfd7bbcd72a8d3e81092b646f4c4427ad2496c2bc1d428c7b5e0ba29430f9R127-R145)`).